### PR TITLE
utils: early comparison of same table

### DIFF
--- a/packages/lime-system/files/usr/lib/lua/lime/utils.lua
+++ b/packages/lime-system/files/usr/lib/lua/lime/utils.lua
@@ -544,6 +544,7 @@ function utils.is_valid_mac(string)
 end
 
 function utils.deepcompare(t1,t2)
+    if t1 == t2 then return true end
     local ty1 = type(t1)
     local ty2 = type(t2)
     if ty1 ~= ty2 then return false end


### PR DESCRIPTION
From this conversation: https://github.com/libremesh/lime-packages/pull/872/files#r619604314
Quoting @G10h4ck:
> An early check `if ty1 == ty2 then return true end` would optimize a bunch of cases ;)
> Moreover this implementation would overflow the heap in case of a back-reference inside the table

I added `if ty1 == ty2 then return true end`, but couldn't reproduce the heap overflow.
What I tried (with the above change already implemented):
```
> t0 = { ["a"] = 1, ["b"] = t0 }
> t1 = { ["a"] = 1, ["b"] = t1 }
> print(utils.deepcompare(t0, t1))
true
> t0 = {}
> t1 = {}
> t0 = { ["a"] = 1, ["b"] = t1 }
> t1 = { ["a"] = 1, ["b"] = t0 }
> print(utils.deepcompare(t0, t1))
false
```