### PR TITLE
pirania: fix page content set, add test

### DIFF
--- a/packages/pirania/files/usr/lib/lua/portal/portal.lua
+++ b/packages/pirania/files/usr/lib/lua/portal/portal.lua
@@ -52,7 +52,7 @@ end
 
 
 function portal.set_page_content(title, main_text, logo, link_title, link_url, background_color)
-    local data = {title=title, main_text=main_texst, logo=logo, link_title=link_title, link_url=link_url, background_color=background_color}
+    local data = {title=title, main_text=main_text, logo=logo, link_title=link_title, link_url=link_url, background_color=background_color}
     local db = shared_state.SharedStateMultiWriter:new('pirania_persistent')
     return db:insert({portal=data})
 end

--- a/packages/pirania/files/usr/libexec/rpcd/pirania
+++ b/packages/pirania/files/usr/libexec/rpcd/pirania
@@ -7,7 +7,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-3.0
 ]]--
-
 local ubus = require "ubus"
 local json = require 'luci.jsonc'
 local uci = require 'uci'
@@ -45,7 +44,14 @@ local function get_portal_page_content(msg)
 end
 
 local function set_portal_page_content(msg)
-    portal.set_page_content(unpack(msg))
+    portal.set_page_content(
+        msg.title,
+        msg.main_text,
+        msg.logo,
+        msg.link_title,
+        msg.link_url,
+        msg.background_color
+    )
     utils.printJson({ status = 'ok'})
 end
 

--- a/packages/pirania/tests/test_pirania_rpcd.lua
+++ b/packages/pirania/tests/test_pirania_rpcd.lua
@@ -88,6 +88,21 @@ describe('pirania rpcd tests #piraniarpcd', function()
         assert.is.equal("error", response.status)
     end)
 
+    it('test set_portal_page_content calls set_page_content', function()
+        local msg = {}
+        msg.title = 'My Portal'
+        msg.main_text = 'my text'
+        msg.logo = 'mylogo'
+        msg.link_title = 'linktitle'
+        msg.link_url = 'http://foo'
+        msg.background_color = '#aabbcc'
+        stub(portal, "set_page_content", function() end)
+        local response  = rpcd_call(pirania, {'call', 'set_portal_page_content'}, json.stringify(msg))
+        assert.stub(portal.set_page_content).was_called_with(
+            msg.title, msg.main_text, msg.logo, msg.link_title,
+            msg.link_url, msg.background_color
+        )
+    end)
 
     before_each('', function()
         snapshot = assert:snapshot()

--- a/packages/pirania/tests/test_portal.lua
+++ b/packages/pirania/tests/test_portal.lua
@@ -46,7 +46,7 @@ describe('Pirania portal tests #portal', function()
         portal.set_page_content(title, main_text, logo, link_title, link_url, bgcolor)
 
         local content = portal.get_page_content()
-        assert.are.same({title=title, background_color=bgcolor, link_title=link_title, link_url=link_url, logo=logo}, content)
+        assert.are.same({title=title, main_text=main_text, background_color=bgcolor, link_title=link_title, link_url=link_url, logo=logo}, content)
 
     end)
 


### PR DESCRIPTION
This fixes two bugs for setting portal page content:
- unpack returns nil: It only works for number indexed (aka lists) tables.
- typo in set_page_content: main_texst, that was unfortunately not tested before. 